### PR TITLE
Allow either web only or all purpose search to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Remember to set the `API_KEY` as your own.
 
     >>> from py_bing_search import PyBingWebSearch
     >>> search_term = "Python Software Foundation"
-    >>> bing_web = PyBingWebSearch('Your-Api-Key-Here', search_term)
+    >>> bing_web = PyBingWebSearch('Your-Api-Key-Here', search_term, web_only=False) # web_only is optional, but should be true to use your web only quota instead of your all purpose quota
     >>> first_fifty_result= bing_web.search(limit=50, format='json') #1-50
     >>> second_fifty_result= bing_web.search(limit=50, format='json') #51-100
 

--- a/py_bing_search/py_bing_search.py
+++ b/py_bing_search/py_bing_search.py
@@ -44,11 +44,16 @@ class PyBingWebException(Exception):
 
 class PyBingWebSearch(PyBingSearch):
 
-    IMAGE_QUERY_BASE = 'https://api.datamarket.azure.com/Bing/Search/Web' \
-                 + '?Query={}&$top={}&$skip={}&$format={}'
+    SEARCH_WEB_BASE = 'https://api.datamarket.azure.com/Bing/Search/Web'
+    WEB_ONLY_BASE = 'https://api.datamarket.azure.com/Bing/SearchWeb/v1/Web'
+    QUERYSTRING_TEMPLATE = '?Query={}&$top={}&$skip={}&$format={}'
 
-    def __init__(self, api_key, query, safe=False):
-        PyBingSearch.__init__(self, api_key, query, self.IMAGE_QUERY_BASE, safe=safe)
+    def __init__(self, api_key, query, web_only=False, safe=False):
+        if web_only:
+            query_base = WEB_ONLY_BASE + QUERYSTRING_TEMPLATE
+        else:
+            query_base = SEARCH_WEB_BASE + QUERYSTRING_TEMPLATE
+        PyBingSearch.__init__(self, api_key, query, query_base, safe=safe)
 
     def _search(self, limit, format):
         '''


### PR DESCRIPTION
This PR https://github.com/tristantao/py-bing-search/pull/6 changed from the web only to the general purpose endpoint. I think either should be possible (it actually looks like this might be a good way to double your free quota if you're so inclined).